### PR TITLE
feat(lustre): add support for lustre fsx file systems mount commands on auto-scaling ignite EC2 instances (AN-146)

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cloud/LaunchConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cloud/LaunchConfig.groovy
@@ -105,6 +105,12 @@ class LaunchConfig extends CascadingConfig<String,Object> {
     }
 
     @ConfigField
+    List<String> getFsxFileSystemsMountCommands() {
+        String fileSystemsCommands = getAttribute('fsxFileSystemsMountCommands')
+        return fileSystemsCommands ? fileSystemsCommands.tokenize(';') : Collections.<String>emptyList()
+    }
+
+    @ConfigField
     MemoryUnit getBootStorageSize() {
         getAttribute('bootStorageSize') as MemoryUnit
     }

--- a/modules/nextflow/src/main/resources/nextflow/cloud/aws/cloud-boot.txt
+++ b/modules/nextflow/src/main/resources/nextflow/cloud/aws/cloud-boot.txt
@@ -34,7 +34,9 @@ region="${zone::-1}"
 #
 # Mount fsx file systems if provided
 #
-[[ '!{fsxFileSystemsMountCommands}' ]] && for fsxMountCommand in '!{fsxFileSystemsMountCommands}'; do $fsxMountCommand || true; done
+mountCommandsString="!{fsxFileSystemsMountCommands}"
+IFS=',' read -ra mountCommandsArray <<< "$mountCommandsString"
+[[ '!{fsxFileSystemsMountCommands}' ]] && for fsxMountCommand in "${mountCommandsArray[@]}"; do $fsxMountCommand || true; done
 
 #
 # Install NEXTFLOW and launch it

--- a/modules/nextflow/src/main/resources/nextflow/cloud/aws/cloud-boot.txt
+++ b/modules/nextflow/src/main/resources/nextflow/cloud/aws/cloud-boot.txt
@@ -32,6 +32,11 @@ region="${zone::-1}"
 [[ '!{dockerPull}' ]] && for x in '!{dockerPull}'; do docker pull $x || true; done
 
 #
+# Mount fsx file systems if provided
+#
+[[ '!{fsxFileSystemsMountCommands}' ]] && for fsxMountCommand in '!{fsxFileSystemsMountCommands}'; do $fsxMountCommand || true; done
+
+#
 # Install NEXTFLOW and launch it
 #
 version="v!{nextflow.version}"


### PR DESCRIPTION
This PR adds the support for mounting lustre fsx file systems by reading the mount commands if provided from the config sent by the pre-build configuration from api-server. This will allow the usage of lustre file systems on auto-scaling ignite ec2 instances.