### PR TITLE
Add fix to allow get credentials from instance role

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cloud/aws/AmazonCloudDriver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cloud/aws/AmazonCloudDriver.groovy
@@ -303,7 +303,9 @@ class AmazonCloudDriver implements CloudDriver {
     }
 
     protected AWSStaticCredentialsProvider getCredentialsProvider0() {
-        new AWSStaticCredentialsProvider(getCredentials0())
+        final creds = getCredentials0()
+        if( !creds ) return null
+        return new AWSStaticCredentialsProvider(creds)
     }
 
 


### PR DESCRIPTION
Fixes an issue when cloud driver throws exception when its not able to get hold of credentials in the system.

This happens when a instance may have an instance role attached as opposed to AWS config or environment variables setup. This fix allows to check and retrieve credentials first. If the credentials are not present, it will attempt to create a client without them, pulling them directly from the instance without throwing an error.